### PR TITLE
Custom Application Icon Fix

### DIFF
--- a/bin/macgap
+++ b/bin/macgap
@@ -84,7 +84,11 @@ FileUtils.cd build_dir.join("Contents") do
   png_icon_path = public_dir.join("application.png")
   icon_path     = public_dir.join("application.icns")
   
+  # Replace automatically generated application.icns with user application.png
   if png_icon_path.exist?
+    if icon_path.exist?
+      FileUtils.rm(icon_path)
+    end
     `sips -s format icns #{png_icon_path} --out #{icon_path}`
   end
 


### PR DESCRIPTION
MacGap produces an error when trying to create an application.icns from the application.png file in root because the default application.icns has already been generated when it attempts to convert. This merely checks whether that is the case before converting and removes it.
